### PR TITLE
Add iOS-style fade-in animation for todo items

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2275,6 +2275,10 @@ body.dark-mode .focus-ring:focus-visible {
     will-change: transform;
 }
 
+.todo-item.fade-in {
+    animation: iosFadeIn 0.45s cubic-bezier(0.36, 0.66, 0.04, 1);
+}
+
 .todo-item.swiping {
     transition: none;
 }
@@ -2329,6 +2333,17 @@ body.dark-mode .swipe-feedback.warning {
     30% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
     70% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
     100% { opacity: 0; transform: translate(-50%, -50%) scale(0.8); }
+}
+
+@keyframes iosFadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
 /* Custom Scrollbar */

--- a/js/script.js
+++ b/js/script.js
@@ -366,7 +366,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function addTodoItemToDOM(todo) {
         const listItem = document.createElement('li');
         listItem.dataset.id = todo.id;
-        listItem.classList.add('todo-item'); // Add todo-item class for touch gestures
+        listItem.classList.add('todo-item', 'fade-in'); // Add todo-item class for touch gestures and animation
         if (todo.completed) {
             listItem.classList.add('completed');
         }
@@ -507,9 +507,14 @@ document.addEventListener('DOMContentLoaded', () => {
             // Update statistics
             updateStats();
         });
-        actionsDiv.appendChild(removeButton);todoContent.appendChild(actionsDiv);
+        actionsDiv.appendChild(removeButton);
+        todoContent.appendChild(actionsDiv);
         listItem.appendChild(todoContent);
         todoList.appendChild(listItem);
+
+        listItem.addEventListener('animationend', () => {
+            listItem.classList.remove('fade-in');
+        }, { once: true });
     }
 
     // Edit todo function


### PR DESCRIPTION
## Summary
- animate todo items with iOS-like fade in when displayed

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840280eb77083318215953037c95873